### PR TITLE
Hotfix: Verify object doctor before to check property.

### DIFF
--- a/utils/requestCheckers.js
+++ b/utils/requestCheckers.js
@@ -46,6 +46,10 @@ const checkExistingField = async (res, Controller, templateId, field) => {
 
 const doctorActive = async (res, doctorId) => {
   const doctor = await findUserByRoleID(doctorId)
+  if (!doctor) {
+    res.status(404).json({ status: 404, message: COMMON_MSG.DOCTOR_NOT_FOUND })
+    return false
+  }
   if (!doctor.isActive) {
     res.status(403).json({ status: 403, message: COMMON_MSG.DOCTOR_INACTIVE })
     return false


### PR DESCRIPTION
This error is related with API crash when trying to access to null object property.