### PR TITLE
FR-230 | Implement endpoints of files (GET, POST, DELETE /files)

### DIFF
--- a/controllers/fileController.js
+++ b/controllers/fileController.js
@@ -17,7 +17,7 @@ exports.createFile = async (req, res) => {
 
   if (!uploadfile || !uploadfile.buffer) {
     return res
-      .status(400)
+      .status(403)
       .send({ status: 'error', message: 'No file provided' })
   }
 
@@ -91,7 +91,8 @@ exports.createFile = async (req, res) => {
     }
 
     const timestamp = Date.now()
-    const key = `${recordId}/${timestamp}-${uploadfile.originalname}`
+    const doctorId = fileTemplate.doctor
+    const key = `${doctorId}/${recordId}/${timestamp}-${uploadfile.originalname}`
     console.log(key)
     const s3Response = await s3Upload(key, uploadfile.buffer)
     const location = s3Response.Location.split('.com/')[1]

--- a/controllers/s3ClientController.js
+++ b/controllers/s3ClientController.js
@@ -20,6 +20,16 @@ exports.s3Upload = (key, body) => {
   return s3.upload(params).promise()
 }
 
+exports.generateS3PreSignedUrl = async (key) => {
+  const params = {
+    Bucket: bucket,
+    Key: key,
+    Expires: 3600
+  }
+
+  return s3.getSignedUrlPromise('getObject', params)
+}
+
 exports.s3Delete = (key) => {
   const params = {
     Bucket: bucket,

--- a/docs/paths/file_operations.yaml
+++ b/docs/paths/file_operations.yaml
@@ -21,6 +21,7 @@ baseFileRoute:
       Content-Type: application/json
 
       {
+        "doctorId": "12345dvdsedf32",
         "recordId": "12345dvdsedf32",
         "templateId": "6789032vbad3295",
         "name": "Consulta 3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "mongodb": "^6.5.0",
         "mongoose": "^8.3.2",
         "multer": "^1.4.5-lts.1",
+        "pdf-parse": "^1.1.1",
         "winston": "^3.14.2",
         "yup": "^1.4.0"
       },
@@ -9597,6 +9598,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -10354,6 +10361,28 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
       "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
       "license": "MIT"
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
+      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
     },
     "node_modules/perfect-scrollbar": {
       "version": "1.5.5",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "mongodb": "^6.5.0",
     "mongoose": "^8.3.2",
     "multer": "^1.4.5-lts.1",
+    "pdf-parse": "^1.1.1",
     "winston": "^3.14.2",
     "yup": "^1.4.0"
   },

--- a/routes/fileRoutes.js
+++ b/routes/fileRoutes.js
@@ -8,7 +8,6 @@ const {
   checkJwt
 } = require('../middlewares/auth0Middleware')
 
-//Crear un archivo
 router.post(
   '/',
   checkJwt,
@@ -34,8 +33,8 @@ router.get(
   requiredPermissions(['read:files']),
   fileController.listFiles
 )
-router.post(
-  '/file',
+router.get(
+  '/',
   checkJwt,
   requiredPermissions(['read:files']),
   fileController.getFileById

--- a/routes/fileRoutes.js
+++ b/routes/fileRoutes.js
@@ -8,8 +8,9 @@ const {
   checkJwt
 } = require('../middlewares/auth0Middleware')
 
+//Crear un archivo
 router.post(
-  '/create',
+  '/',
   checkJwt,
   requiredPermissions(['create:files']),
   upload.single('file'),


### PR DESCRIPTION
I have implemented GET, POST & DELETE /files endpoint functionality.

<img width="257" alt="image" src="https://github.com/user-attachments/assets/f500249c-9ffd-4159-b2a3-cdba45a431d4">

This refactoring now implements the multipart-form data request, which are typically used to send files. We retrieve the file metadata and the corresponding URL of the file stored in S3.

This URL is pre-assigned by the service, so the client does not need to perform any further steps to get it, this file is protected by the CORS policies that are defined by AWS S3.

```
[
  {
    “AllowedOrigins“: [”http://localhost:3000"],
    “AllowedMethods“: [”GET”, ‘HEAD’, ‘PUT’, ‘DELETE’],
    “AllowedHeaders“: [”*"],
    “ExposeHeaders“: [”ETag"],
    “MaxAgeSeconds": 3000
  }
]
```
If you want to test it using localhost, make sure you are using port 3000, just click the link if you're using browser.